### PR TITLE
use safe indexing of error matrix (detects error!)

### DIFF
--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -1287,7 +1287,7 @@ namespace GeFaST {
         // calculate lambda
         double lambda = 1.0;
         for (int pos1 = 0; pos1 < seq_len; pos1++) {
-            lambda = lambda * error_matrix[tvec[pos1]][qind[pos1]];
+            lambda = lambda * error_matrix.at(tvec[pos1]).at(qind[pos1]);
         }
 
         if (lambda < 0 || lambda > 1) throw std::runtime_error("Bad lambda.");


### PR DESCRIPTION
I was playing around with the code to try to add support for PacBio quality scores (offset 33, max score 93), and I found an indexing error.  The error matrix is generated such that the first entry is the first valid score (e.g., `0...41` for Illumina 1.8), but then it is being accessed using raw quality scores (e.g., `33...74`).  Using `[ ]` for element extraction was silently pulling the incorrect data; in this pull request I switched to indexing with `.at()` in order to demonstrate the error, but I didn't want to correct it because there are several options, all of which require some degree of refactoring.